### PR TITLE
renderer: improve unsupported block panics

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -301,7 +301,7 @@ func (r *nodeRenderer) renderListItem(w util.BufWriter, source []byte, node ast.
 		}
 
 		r.c.Set(node, block)
-		r.c.AppendBlock(block, "here")
+		r.c.AppendBlock(block)
 		r.c.Descend(node)
 	} else {
 		r.c.Ascend()


### PR DESCRIPTION
Add some data for diagnostics, otherwise you just get this:

```
panic: unknown block type: <nil>
```

after:

```
panic: unknown block type: <nil> ([{"text":{"content":"PROPERTY"}}])
```