### PR TITLE
renderer: support GitHub-syntax callouts

### DIFF
--- a/markdown/golden/TestProcessor/callout.md.golden
+++ b/markdown/golden/TestProcessor/callout.md.golden
@@ -1,0 +1,79 @@
+[]notionapi.Block{
+	&notionapi.Heading1Block{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("heading_1"),
+		},
+		Heading1: notionapi.Heading{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{
+				Content: "MSP Testbed infrastructure",
+			}},
+			{Text: &notionapi.Text{Content: " operations"}},
+		}},
+	},
+	&notionapi.CalloutBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("callout"),
+		},
+		Callout: notionapi.Callout{
+			RichText: []notionapi.RichText{{Text: &notionapi.Text{Content: "Generated from: unknown revision of "}}},
+			Icon: &notionapi.Icon{
+				Type:  notionapi.FileType("emoji"),
+				Emoji: valast.Ptr(notionapi.Emoji("🔔")),
+			},
+		},
+	},
+	&notionapi.ParagraphBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("paragraph"),
+		},
+		Paragraph: notionapi.Paragraph{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{Content: "This document describes operational guidance for MSP Testbed"}},
+			{Text: &notionapi.Text{Content: " infrastructure."}},
+			{Text: &notionapi.Text{Content: "This service is operated on the "}},
+			{Text: &notionapi.Text{
+				Content: "Managed Services Platform (MSP)",
+				Link:    &notionapi.Link{Url: "https://sourcegraph.notion.site/712a0389f54c4d3a90d069aa2d979a59"},
+			}},
+			{Text: &notionapi.Text{Content: "."}},
+		}},
+	},
+	&notionapi.CalloutBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("callout"),
+		},
+		Callout: notionapi.Callout{
+			RichText: []notionapi.RichText{
+				{Text: &notionapi.Text{Content: "If this is your first time here, you must follow the "}},
+				{Text: &notionapi.Text{
+					Content: "sourcegraph/managed-services 'Tooling setup' guide",
+					Link:    &notionapi.Link{Url: "https://github.com/sourcegraph/managed-services/blob/main/README.md"},
+				}},
+				{Text: &notionapi.Text{Content: " as well to clone the service definitions repository and set up the prerequisite"}},
+				{Text: &notionapi.Text{Content: " tooling."}},
+			},
+			Icon: &notionapi.Icon{
+				Type:  notionapi.FileType("emoji"),
+				Emoji: valast.Ptr(notionapi.Emoji("⭐")),
+			},
+		},
+	},
+	&notionapi.ParagraphBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("paragraph"),
+		},
+		Paragraph: notionapi.Paragraph{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{Content: "If you need assistance with MSP infrastructure, reach out to the "}},
+			{Text: &notionapi.Text{
+				Content: "Core Services",
+				Link:    &notionapi.Link{Url: "https://sourcegraph.notion.site/ed8af5ecf15545b292816ebba261a93c"},
+			}},
+			{Text: &notionapi.Text{Content: " team in"}},
+			{Text: &notionapi.Text{Content: " #discuss-core-services."}},
+		}},
+	},
+}

--- a/markdown/golden/TestProcessor/fencedblock.md.golden
+++ b/markdown/golden/TestProcessor/fencedblock.md.golden
@@ -13,8 +13,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`,
+return ast.WalkSkipChildren, nil`,
 				}},
 			},
 			Language: "plain text",
@@ -32,8 +31,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`}}},
+return ast.WalkSkipChildren, nil`}}},
 			Language: "go",
 		},
 	},

--- a/markdown/golden/TestProcessor/index.md#03.golden
+++ b/markdown/golden/TestProcessor/index.md#03.golden
@@ -238,8 +238,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`}}},
+return ast.WalkSkipChildren, nil`}}},
 			Language: "plain text",
 		},
 	},
@@ -269,8 +268,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`}}},
+return ast.WalkSkipChildren, nil`}}},
 			Language: "go",
 		},
 	},

--- a/renderer/cursor.go
+++ b/renderer/cursor.go
@@ -29,6 +29,8 @@ func (c *cursor) RichText() *notionapi.RichText {
 		return &block.Heading3.RichText[len(block.Heading3.RichText)-1]
 	case *notionapi.QuoteBlock:
 		return &block.Quote.RichText[len(block.Quote.RichText)-1]
+	case *notionapi.CalloutBlock:
+		return &block.Callout.RichText[len(block.Callout.RichText)-1]
 	default:
 		fmt.Printf("unknown block type: %T\n", block)
 	}
@@ -68,6 +70,8 @@ func (c *cursor) AppendRichText(rt *notionapi.RichText) {
 		block.Heading3.RichText = append(block.Heading3.RichText, rts...)
 	case *notionapi.QuoteBlock:
 		block.Quote.RichText = append(block.Quote.RichText, rts...)
+	case *notionapi.CalloutBlock:
+		block.Callout.RichText = append(block.Callout.RichText, rts...)
 	default:
 		panic(fmt.Sprintf("unknown block type: %T\n", block))
 	}
@@ -94,6 +98,8 @@ func (c *cursor) AppendBlock(b notionapi.Block, things ...string) {
 			block.Heading3.Children = append(block.Heading3.Children, b)
 		case *notionapi.QuoteBlock:
 			block.Quote.Children = append(block.Quote.Children, b)
+		case *notionapi.CalloutBlock:
+			block.Callout.Children = append(block.Callout.Children, b)
 		default:
 			panic(fmt.Sprintf("unknown block type: %T\n", block))
 		}

--- a/renderer/linkresolver.go
+++ b/renderer/linkresolver.go
@@ -1,14 +1,28 @@
 package renderer
 
+import "errors"
+
+var ErrDiscardLink = errors.New("discard link")
+
 // LinkResolver can be implemented to modify Markdown links.
 type LinkResolver interface {
 	// ResolveLink accepts a link and returns it as-is or modified as desired,
 	// for example to resolve an appropriate absolute link to the relevant
 	// resource (e.g. another Notion document or a blob view).
+	//
+	// If ErrDiscardLink is returned, the link is converted into a plain text
+	// element.
 	ResolveLink(link string) (string, error)
 }
 
-// noopLinkResolver returns all links as-is and unmodified.
+// noopLinkResolver returns all links as-is and unmodified. It should be used
+// as the default LinkResolver.
 type noopLinkResolver struct{}
 
 func (noopLinkResolver) ResolveLink(link string) (string, error) { return link, nil }
+
+// DiscardLinkResolver discards all links, using ErrDiscardLink to indicate
+// all links should be rendered as plain text.
+type DiscardLinkResolver struct{}
+
+func (DiscardLinkResolver) ResolveLink(link string) (string, error) { return "", ErrDiscardLink }

--- a/renderer/linkresolver_test.go
+++ b/renderer/linkresolver_test.go
@@ -1,0 +1,41 @@
+package renderer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/jomei/notionapi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/notionreposync/markdown"
+	"github.com/sourcegraph/notionreposync/renderer"
+	"github.com/sourcegraph/notionreposync/renderer/renderertest"
+)
+
+func TestDiscardLinkResolver(t *testing.T) {
+	ctx := context.Background()
+	blockUpdater := &renderertest.MockBlockUpdater{}
+
+	p := markdown.NewProcessor(ctx, blockUpdater,
+		renderer.WithLinkResolver(renderer.DiscardLinkResolver{}))
+	err := p.ProcessMarkdown([]byte("[This link](#foo) should be [discarded](#bar) and [this too](#asdf)"))
+	assert.NoError(t, err)
+
+	// Result should not have any Links
+	autogold.Expect([]notionapi.Block{&notionapi.ParagraphBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("paragraph"),
+		},
+		Paragraph: notionapi.Paragraph{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{
+				Content: "This link",
+			}},
+			{Text: &notionapi.Text{Content: " should be "}},
+			{Text: &notionapi.Text{Content: "discarded"}},
+			{Text: &notionapi.Text{Content: " and "}},
+			{Text: &notionapi.Text{Content: "this too"}},
+		}},
+	}}).Equal(t, blockUpdater.GetAddedBlocks())
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"bytes"
 	"context"
+	"regexp"
 	"strings"
 
 	"github.com/jomei/notionapi"
@@ -169,17 +170,54 @@ func (r *nodeRenderer) renderHeading(w util.BufWriter, source []byte, node ast.N
 	return ast.WalkContinue, nil
 }
 
+// Match for e.g. '[!IMPORTANT]'-style GitHub callouts in blockquotes.
+var calloutRegexp = regexp.MustCompile(`^\[!([A-Z]+)\]`)
+
 func (r *nodeRenderer) renderBlockquote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		block := &notionapi.QuoteBlock{
-			BasicBlock: notionapi.BasicBlock{
-				Object: notionapi.ObjectTypeBlock,
-				Type:   notionapi.BlockQuote,
-			},
-			Quote: notionapi.Quote{
-				RichText: []notionapi.RichText{},
-			},
+		// Look for a callout-looking thing.
+		var block notionapi.Block
+		if matches := calloutRegexp.FindSubmatch(node.Text(source)); len(matches) > 0 {
+			block = &notionapi.CalloutBlock{
+				BasicBlock: notionapi.BasicBlock{
+					Object: notionapi.ObjectTypeBlock,
+					Type:   notionapi.BlockCallout,
+				},
+				Callout: notionapi.Callout{
+					RichText: []notionapi.RichText{},
+					Icon: func() *notionapi.Icon {
+						var emoji string
+						// matches[1] is the capture group in calloutRegexp
+						switch string(matches[1]) {
+						case "NOTE":
+							emoji = "🔔"
+						case "IMPORTANT":
+							emoji = "⭐"
+						case "WARNING":
+							emoji = "🚨"
+						default:
+							emoji = "💡"
+						}
+						e := notionapi.Emoji(emoji)
+						return &notionapi.Icon{
+							Type:  "emoji",
+							Emoji: &e,
+						}
+					}(),
+				},
+			}
+		} else {
+			block = &notionapi.QuoteBlock{
+				BasicBlock: notionapi.BasicBlock{
+					Object: notionapi.ObjectTypeBlock,
+					Type:   notionapi.BlockQuote,
+				},
+				Quote: notionapi.Quote{
+					RichText: []notionapi.RichText{},
+				},
+			}
 		}
+
 		r.c.Set(node, block)
 		r.c.AppendBlock(block)
 		r.c.Descend(node)
@@ -459,9 +497,56 @@ func (r *nodeRenderer) renderText(w util.BufWriter, source []byte, node ast.Node
 		return ast.WalkContinue, nil
 	}
 
+	// Special handling for callouts - we want to ignore the callout indicator,
+	// as defined in calloutRegexp, by skipping any content within the range of
+	// the match. To do this, we need to figure out a sliding window because
+	// the AST parses the callout indicator as 3 nodes:
+	// - "["
+	// - "!NOTE"
+	// - "]"
+	// So we assemble all possible 3-node window (3-grams) and check each for
+	// a callout indicator. If there is one, we drop this content.
+	for _, gram := range getNeighbouring3Grams(node) {
+		if nodeMatchesRegexp(calloutRegexp, source, gram[0], gram[1], gram[2]) {
+			return ast.WalkSkipChildren, nil
+		}
+	}
+
 	r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: string(segment.Value(source))}})
 
 	return ast.WalkContinue, nil
+}
+
+// getNeighbouring3Grams returns a list of 3-grams of the given node's neighbours
+// including the node itself. Elements of each 3-gram may be nil - callers should
+// check before using each node.
+func getNeighbouring3Grams(node ast.Node) [][3]ast.Node {
+	var windows [][3]ast.Node
+	var prev, middle, next = node.PreviousSibling(), node, node.NextSibling()
+	windows = append(windows, [3]ast.Node{prev, middle, next})
+	if next != nil {
+		windows = append(windows, [3]ast.Node{node, next, next.NextSibling()})
+	}
+	if prev != nil {
+		windows = append(windows, [3]ast.Node{prev.PreviousSibling(), prev, node})
+	}
+	return windows
+}
+
+// nodeMatchesRegexp returns true if the given nodes match the callout
+// indicator as defined by calloutRegexp.
+func nodeMatchesRegexp(re *regexp.Regexp, source []byte, prev, middle, next ast.Node) bool {
+	if prev == nil || middle == nil || next == nil {
+		return false
+	}
+	ptext, ntext := prev.Text(source), next.Text(source)
+	if bytes.Equal(ptext, []byte("[")) && bytes.Equal(ntext, []byte("]")) {
+		maybeCallout := string(ptext) + string(middle.Text(source)) + string(ntext)
+		if matches := re.FindStringSubmatch(maybeCallout); len(matches) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *nodeRenderer) renderString(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -233,6 +233,10 @@ func (r *nodeRenderer) renderCodeBlock(w util.BufWriter, source []byte, node ast
 		var sb strings.Builder
 		for i := 0; i < node.Lines().Len(); i++ {
 			line := node.Lines().At(i)
+			lineContents := line.Value(source)
+			if i == node.Lines().Len()-1 { // trim trailing newlines
+				lineContents = bytes.TrimRight(lineContents, "\n")
+			}
 			sb.Write(line.Value(source))
 		}
 
@@ -270,7 +274,11 @@ func (r *nodeRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 		var sb strings.Builder
 		for i := 0; i < node.Lines().Len(); i++ {
 			line := node.Lines().At(i)
-			sb.Write(line.Value(source))
+			lineContents := line.Value(source)
+			if i == node.Lines().Len()-1 { // trim trailing newlines
+				lineContents = bytes.TrimRight(lineContents, "\n")
+			}
+			sb.Write(lineContents)
 		}
 
 		rts := []notionapi.RichText{{Text: &notionapi.Text{Content: sb.String()}}}

--- a/testdata/ref/callout.md
+++ b/testdata/ref/callout.md
@@ -1,0 +1,12 @@
+# MSP Testbed infrastructure operations
+
+> [!NOTE]
+> Generated from: unknown revision of https://github.com/sourcegraph/managed-services
+
+This document describes operational guidance for MSP Testbed infrastructure.
+This service is operated on the [Managed Services Platform (MSP)](https://sourcegraph.notion.site/712a0389f54c4d3a90d069aa2d979a59).
+
+> [!IMPORTANT]
+> If this is your first time here, you must follow the [sourcegraph/managed-services 'Tooling setup' guide](https://github.com/sourcegraph/managed-services/blob/main/README.md) as well to clone the service definitions repository and set up the prerequisite tooling.
+
+If you need assistance with MSP infrastructure, reach out to the [Core Services](https://sourcegraph.notion.site/ed8af5ecf15545b292816ebba261a93c) team in #discuss-core-services.


### PR DESCRIPTION
GitHub allows the following format for callouts:

```
> [!IMPORTANT]  
> Crucial information necessary for users to succeed.
```

e.g.

> [!IMPORTANT]  
> Crucial information necessary for users to succeed.

This adds some special handling to the quote renderer to render callouts as Notion callouts, and also strip the prefix `[!IMPORTANT]` from the actual callout. See golden test, and also a real life example of the output:

<img width="882" alt="image" src="https://github.com/sourcegraph/notionreposync/assets/23356519/a39f861f-653a-440a-b599-0f8b58376dd3">
