### PR TITLE
renderer: trim trailing newlines from code blocks

### DIFF
--- a/markdown/golden/TestProcessor/fencedblock.md.golden
+++ b/markdown/golden/TestProcessor/fencedblock.md.golden
@@ -13,8 +13,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`,
+return ast.WalkSkipChildren, nil`,
 				}},
 			},
 			Language: "plain text",
@@ -32,8 +31,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`}}},
+return ast.WalkSkipChildren, nil`}}},
 			Language: "go",
 		},
 	},

--- a/markdown/golden/TestProcessor/index.md#03.golden
+++ b/markdown/golden/TestProcessor/index.md#03.golden
@@ -238,8 +238,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`}}},
+return ast.WalkSkipChildren, nil`}}},
 			Language: "plain text",
 		},
 	},
@@ -269,8 +268,7 @@ for c := node.FirstChild(); c != nil; c = c.NextSibling() {
     txt = txt + string(segment.Value(source))
 }
 r.c.AppendRichText(&notionapi.RichText{Text: &notionapi.Text{Content: txt}, Annotations: &notionapi.Annotations{Code: true}})
-return ast.WalkSkipChildren, nil
-`}}},
+return ast.WalkSkipChildren, nil`}}},
 			Language: "go",
 		},
 	},

--- a/renderer/linkresolver.go
+++ b/renderer/linkresolver.go
@@ -1,14 +1,28 @@
 package renderer
 
+import "errors"
+
+var ErrDiscardLink = errors.New("discard link")
+
 // LinkResolver can be implemented to modify Markdown links.
 type LinkResolver interface {
 	// ResolveLink accepts a link and returns it as-is or modified as desired,
 	// for example to resolve an appropriate absolute link to the relevant
 	// resource (e.g. another Notion document or a blob view).
+	//
+	// If ErrDiscardLink is returned, the link is converted into a plain text
+	// element.
 	ResolveLink(link string) (string, error)
 }
 
-// noopLinkResolver returns all links as-is and unmodified.
+// noopLinkResolver returns all links as-is and unmodified. It should be used
+// as the default LinkResolver.
 type noopLinkResolver struct{}
 
 func (noopLinkResolver) ResolveLink(link string) (string, error) { return link, nil }
+
+// DiscardLinkResolver discards all links, using ErrDiscardLink to indicate
+// all links should be rendered as plain text.
+type DiscardLinkResolver struct{}
+
+func (DiscardLinkResolver) ResolveLink(link string) (string, error) { return "", ErrDiscardLink }

--- a/renderer/linkresolver_test.go
+++ b/renderer/linkresolver_test.go
@@ -1,0 +1,41 @@
+package renderer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/jomei/notionapi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/notionreposync/markdown"
+	"github.com/sourcegraph/notionreposync/renderer"
+	"github.com/sourcegraph/notionreposync/renderer/renderertest"
+)
+
+func TestDiscardLinkResolver(t *testing.T) {
+	ctx := context.Background()
+	blockUpdater := &renderertest.MockBlockUpdater{}
+
+	p := markdown.NewProcessor(ctx, blockUpdater,
+		renderer.WithLinkResolver(renderer.DiscardLinkResolver{}))
+	err := p.ProcessMarkdown([]byte("[This link](#foo) should be [discarded](#bar) and [this too](#asdf)"))
+	assert.NoError(t, err)
+
+	// Result should not have any Links
+	autogold.Expect([]notionapi.Block{&notionapi.ParagraphBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("paragraph"),
+		},
+		Paragraph: notionapi.Paragraph{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{
+				Content: "This link",
+			}},
+			{Text: &notionapi.Text{Content: " should be "}},
+			{Text: &notionapi.Text{Content: "discarded"}},
+			{Text: &notionapi.Text{Content: " and "}},
+			{Text: &notionapi.Text{Content: "this too"}},
+		}},
+	}}).Equal(t, blockUpdater.GetAddedBlocks())
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -233,6 +233,10 @@ func (r *nodeRenderer) renderCodeBlock(w util.BufWriter, source []byte, node ast
 		var sb strings.Builder
 		for i := 0; i < node.Lines().Len(); i++ {
 			line := node.Lines().At(i)
+			lineContents := line.Value(source)
+			if i == node.Lines().Len()-1 { // trim trailing newlines
+				lineContents = bytes.TrimRight(lineContents, "\n")
+			}
 			sb.Write(line.Value(source))
 		}
 
@@ -270,7 +274,11 @@ func (r *nodeRenderer) renderFencedCodeBlock(w util.BufWriter, source []byte, no
 		var sb strings.Builder
 		for i := 0; i < node.Lines().Len(); i++ {
 			line := node.Lines().At(i)
-			sb.Write(line.Value(source))
+			lineContents := line.Value(source)
+			if i == node.Lines().Len()-1 { // trim trailing newlines
+				lineContents = bytes.TrimRight(lineContents, "\n")
+			}
+			sb.Write(lineContents)
 		}
 
 		rts := []notionapi.RichText{{Text: &notionapi.Text{Content: sb.String()}}}


### PR DESCRIPTION
This PR trims trailing newlines in the code blocks. Currently, a trailing new line is retained from the Markdown AST, which is visible on all code blocks in Notion.