### PR TITLE
renderer: allow LinkResolvers to return ErrDiscardLink

### DIFF
--- a/renderer/linkresolver.go
+++ b/renderer/linkresolver.go
@@ -1,14 +1,28 @@
 package renderer
 
+import "errors"
+
+var ErrDiscardLink = errors.New("discard link")
+
 // LinkResolver can be implemented to modify Markdown links.
 type LinkResolver interface {
 	// ResolveLink accepts a link and returns it as-is or modified as desired,
 	// for example to resolve an appropriate absolute link to the relevant
 	// resource (e.g. another Notion document or a blob view).
+	//
+	// If ErrDiscardLink is returned, the link is converted into a plain text
+	// element.
 	ResolveLink(link string) (string, error)
 }
 
-// noopLinkResolver returns all links as-is and unmodified.
+// noopLinkResolver returns all links as-is and unmodified. It should be used
+// as the default LinkResolver.
 type noopLinkResolver struct{}
 
 func (noopLinkResolver) ResolveLink(link string) (string, error) { return link, nil }
+
+// DiscardLinkResolver discards all links, using ErrDiscardLink to indicate
+// all links should be rendered as plain text.
+type DiscardLinkResolver struct{}
+
+func (DiscardLinkResolver) ResolveLink(link string) (string, error) { return "", ErrDiscardLink }

--- a/renderer/linkresolver_test.go
+++ b/renderer/linkresolver_test.go
@@ -1,0 +1,41 @@
+package renderer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/jomei/notionapi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/notionreposync/markdown"
+	"github.com/sourcegraph/notionreposync/renderer"
+	"github.com/sourcegraph/notionreposync/renderer/renderertest"
+)
+
+func TestDiscardLinkResolver(t *testing.T) {
+	ctx := context.Background()
+	blockUpdater := &renderertest.MockBlockUpdater{}
+
+	p := markdown.NewProcessor(ctx, blockUpdater,
+		renderer.WithLinkResolver(renderer.DiscardLinkResolver{}))
+	err := p.ProcessMarkdown([]byte("[This link](#foo) should be [discarded](#bar) and [this too](#asdf)"))
+	assert.NoError(t, err)
+
+	// Result should not have any Links
+	autogold.Expect([]notionapi.Block{&notionapi.ParagraphBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("paragraph"),
+		},
+		Paragraph: notionapi.Paragraph{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{
+				Content: "This link",
+			}},
+			{Text: &notionapi.Text{Content: " should be "}},
+			{Text: &notionapi.Text{Content: "discarded"}},
+			{Text: &notionapi.Text{Content: " and "}},
+			{Text: &notionapi.Text{Content: "this too"}},
+		}},
+	}}).Equal(t, blockUpdater.GetAddedBlocks())
+}


### PR DESCRIPTION
Notion errors on local anchor links like `[bar](#foo)`. Until we have a good solution for the local anchors problem (https://github.com/sourcegraph/notionreposync/issues/8), it can be useful to simply convert these elements into plain text.

This PR allows `LinkResolver` implementations to return `ErrDiscardLink`, which is handled in `Renderer` by appending a plain text block instead of a link.