### PR TITLE
feat: add support for tables

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ func main() {
 
 	blocks := []notionapi.Block{}
 	repo, err := NewRepo(repoPath, "sourcegraph/sourcegraph")
+	if err != nil {
+		panic(err)
+	}
 	if err := Import(context.Background(), client, repo, nd); err != nil {
 		panic(err)
 	}

--- a/markdown/golden/TestProcessor/table.md.golden
+++ b/markdown/golden/TestProcessor/table.md.golden
@@ -103,4 +103,38 @@
 			},
 		},
 	},
+	&notionapi.TableBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("table"),
+		},
+		Table: notionapi.Table{
+			TableWidth:      3,
+			HasColumnHeader: true,
+			Children: notionapi.Blocks{
+				&notionapi.TableRowBlock{
+					BasicBlock: notionapi.BasicBlock{
+						Object: notionapi.ObjectType("block"),
+						Type:   notionapi.BlockType("table_row"),
+					},
+					TableRow: notionapi.TableRow{Cells: [][]notionapi.RichText{
+						{{Text: &notionapi.Text{Content: "A"}}},
+						{{Text: &notionapi.Text{Content: "B"}}},
+						{{Text: &notionapi.Text{Content: "C"}}},
+					}},
+				},
+				&notionapi.TableRowBlock{
+					BasicBlock: notionapi.BasicBlock{
+						Object: notionapi.ObjectType("block"),
+						Type:   notionapi.BlockType("table_row"),
+					},
+					TableRow: notionapi.TableRow{Cells: [][]notionapi.RichText{
+						{{Text: &notionapi.Text{Content: "1"}}},
+						{{Text: &notionapi.Text{Content: "1"}}},
+						{{Text: &notionapi.Text{Content: "1"}}},
+					}},
+				},
+			},
+		},
+	},
 }

--- a/markdown/golden/TestProcessor/table.md.golden
+++ b/markdown/golden/TestProcessor/table.md.golden
@@ -1,0 +1,106 @@
+[]notionapi.Block{
+	&notionapi.Heading1Block{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("heading_1"),
+		},
+		Heading1: notionapi.Heading{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{
+				Content: "We can use tables",
+			}},
+			{Text: &notionapi.Text{Content: " too"}},
+		}},
+	},
+	&notionapi.ParagraphBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("paragraph"),
+		},
+		Paragraph: notionapi.Paragraph{RichText: []notionapi.RichText{
+			{Text: &notionapi.Text{Content: "Glorious days ahead"}},
+			{Text: &notionapi.Text{Content: "!"}},
+		}},
+	},
+	&notionapi.TableBlock{
+		BasicBlock: notionapi.BasicBlock{
+			Object: notionapi.ObjectType("block"),
+			Type:   notionapi.BlockType("table"),
+		},
+		Table: notionapi.Table{
+			TableWidth:      3,
+			HasColumnHeader: true,
+			Children: notionapi.Blocks{
+				&notionapi.TableRowBlock{
+					BasicBlock: notionapi.BasicBlock{
+						Object: notionapi.ObjectType("block"),
+						Type:   notionapi.BlockType("table_row"),
+					},
+					TableRow: notionapi.TableRow{Cells: [][]notionapi.RichText{
+						{
+							{Text: &notionapi.Text{
+								Content: "A",
+							}},
+						},
+						{{Text: &notionapi.Text{Content: "B"}}},
+						{{Text: &notionapi.Text{Content: "C"}}},
+					}},
+				},
+				&notionapi.TableRowBlock{
+					BasicBlock: notionapi.BasicBlock{
+						Object: notionapi.ObjectType("block"),
+						Type:   notionapi.BlockType("table_row"),
+					},
+					TableRow: notionapi.TableRow{Cells: [][]notionapi.RichText{
+						{{Text: &notionapi.Text{Content: "1"}}},
+						{{Text: &notionapi.Text{Content: "1"}}},
+						{{Text: &notionapi.Text{Content: "1"}}},
+					}},
+				},
+				&notionapi.TableRowBlock{
+					BasicBlock: notionapi.BasicBlock{
+						Object: notionapi.ObjectType("block"),
+						Type:   notionapi.BlockType("table_row"),
+					},
+					TableRow: notionapi.TableRow{Cells: [][]notionapi.RichText{
+						{
+							{
+								Text:        &notionapi.Text{Content: "foo"},
+								Annotations: &notionapi.Annotations{Italic: true},
+							},
+							{Text: &notionapi.Text{Content: " is a common "}},
+							{
+								Text:        &notionapi.Text{Content: "term"},
+								Annotations: &notionapi.Annotations{Italic: true},
+							},
+						},
+						{{
+							Text:        &notionapi.Text{Content: "bar"},
+							Annotations: &notionapi.Annotations{Italic: true},
+						}},
+						{{
+							Text:        &notionapi.Text{Content: "baz"},
+							Annotations: &notionapi.Annotations{Bold: true},
+						}},
+					}},
+				},
+				&notionapi.TableRowBlock{
+					BasicBlock: notionapi.BasicBlock{
+						Object: notionapi.ObjectType("block"),
+						Type:   notionapi.BlockType("table_row"),
+					},
+					TableRow: notionapi.TableRow{Cells: [][]notionapi.RichText{
+						{{Text: &notionapi.Text{
+							Content: "link",
+							Link:    &notionapi.Link{Url: "https://github.com"},
+						}}},
+						{{
+							Text:        &notionapi.Text{Content: "code"},
+							Annotations: &notionapi.Annotations{Code: true},
+						}},
+						{},
+					}},
+				},
+			},
+		},
+	},
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -24,7 +24,10 @@ func NewProcessor(ctx context.Context, blocks renderer.BlockUpdater, opts ...ren
 		goldmark.New(
 			goldmark.WithExtensions(extension.GFM),
 			goldmark.WithRenderer(
-				goldmarkrenderer.NewRenderer(goldmarkrenderer.WithNodeRenderers(util.Prioritized(r, 1000))),
+				// Default renderer priority is 1000 in the docs, but the GFM extensions also
+				// injects renderers for the tables, which are set to be 500, and would overrides
+				// our custom implementation if we didn't instead set the priority to 200.
+				goldmarkrenderer.NewRenderer(goldmarkrenderer.WithNodeRenderers(util.Prioritized(r, 200))),
 			),
 		),
 	}

--- a/notionreposync.go
+++ b/notionreposync.go
@@ -27,7 +27,7 @@ func Import(ctx context.Context, client *notionapi.Client, repo *Repo, nd *Notio
 		// }
 		println("🦀", "rendering", d.Path)
 
-		notionPageID := string(nd.PageID)
+		notionPageID := string(d.ID)
 		processor := markdown.NewProcessor(
 			ctx,
 			notion.NewPageBlockUpdater(client, notionPageID),

--- a/notionreposync.go
+++ b/notionreposync.go
@@ -22,9 +22,6 @@ func Import(ctx context.Context, client *notionapi.Client, repo *Repo, nd *Notio
 	}
 
 	err := repo.Walk(func(d *Document) error {
-		// if d.Path != "index.md" && d.Path != "ref/ol.md" {
-		// 	return nil
-		// }
 		println("🦀", "rendering", d.Path)
 
 		notionPageID := string(d.ID)

--- a/renderer/cursor.go
+++ b/renderer/cursor.go
@@ -32,6 +32,8 @@ func (c *cursor) RichText() *notionapi.RichText {
 		return &block.Quote.RichText[len(block.Quote.RichText)-1]
 	case *notionapi.CalloutBlock:
 		return &block.Callout.RichText[len(block.Callout.RichText)-1]
+	case *notionapi.TableRowBlock:
+		return &block.TableRow.Cells[len(block.TableRow.Cells)-1][len(block.TableRow.Cells[len(block.TableRow.Cells)-1])-1]
 	default:
 		panic(errUnknownBlock(block, nil))
 	}
@@ -72,6 +74,10 @@ func (c *cursor) AppendRichText(rt *notionapi.RichText) {
 		block.Quote.RichText = append(block.Quote.RichText, rts...)
 	case *notionapi.CalloutBlock:
 		block.Callout.RichText = append(block.Callout.RichText, rts...)
+	case *notionapi.TableBlock:
+		panic(rts[0].Text.Content)
+	case *notionapi.TableRowBlock:
+		block.TableRow.Cells[len(block.TableRow.Cells)-1] = append(block.TableRow.Cells[len(block.TableRow.Cells)-1], rts...)
 	default:
 		panic(errUnknownBlock(block, rts))
 	}
@@ -79,8 +85,6 @@ func (c *cursor) AppendRichText(rt *notionapi.RichText) {
 
 func (c *cursor) AppendBlock(b notionapi.Block) {
 	if c.cur.Kind() == ast.KindDocument {
-		c.rootBlocks = append(c.rootBlocks, b)
-	} else if c.cur.Parent().Kind() == ast.KindDocument {
 		c.rootBlocks = append(c.rootBlocks, b)
 	} else {
 		switch block := c.Block().(type) {
@@ -100,6 +104,8 @@ func (c *cursor) AppendBlock(b notionapi.Block) {
 			block.Quote.Children = append(block.Quote.Children, b)
 		case *notionapi.CalloutBlock:
 			block.Callout.Children = append(block.Callout.Children, b)
+		case *notionapi.TableBlock:
+			block.Table.Children = append(block.Table.Children, b)
 		default:
 			panic(errUnknownBlock(block, b))
 		}

--- a/renderer/cursor.go
+++ b/renderer/cursor.go
@@ -74,8 +74,6 @@ func (c *cursor) AppendRichText(rt *notionapi.RichText) {
 		block.Quote.RichText = append(block.Quote.RichText, rts...)
 	case *notionapi.CalloutBlock:
 		block.Callout.RichText = append(block.Callout.RichText, rts...)
-	case *notionapi.TableBlock:
-		panic(rts[0].Text.Content)
 	case *notionapi.TableRowBlock:
 		block.TableRow.Cells[len(block.TableRow.Cells)-1] = append(block.TableRow.Cells[len(block.TableRow.Cells)-1], rts...)
 	default:

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -164,7 +164,6 @@ func (r *nodeRenderer) renderTableHeader(w util.BufWriter, source []byte, node a
 		r.c.Ascend()
 	}
 
-	// block.Table.HasColumnHeader = true
 	return ast.WalkContinue, nil
 }
 
@@ -187,8 +186,7 @@ func (r *nodeRenderer) renderTableRow(w util.BufWriter, source []byte, node ast.
 		bl := r.c.Block()
 		block, ok := bl.(*notionapi.TableRowBlock)
 		if !ok {
-			fmt.Printf("%T", bl)
-			panic("foo")
+			return ast.WalkStop, fmt.Errorf("expected current block to be a notionapi.TableRowBlock but got %T", bl)
 		}
 		// Take note of the width of the table.
 		width := len(block.TableRow.Cells)
@@ -199,8 +197,7 @@ func (r *nodeRenderer) renderTableRow(w util.BufWriter, source []byte, node ast.
 		bl = r.c.Block()
 		parentBlock, ok := bl.(*notionapi.TableBlock)
 		if !ok {
-			fmt.Printf("%T", bl)
-			panic("foo")
+			return ast.WalkStop, fmt.Errorf("expected parent block to be a notionapi.TableBlock but got %T", bl)
 		}
 
 		// Set the width of the table.
@@ -214,8 +211,7 @@ func (r *nodeRenderer) renderTableCell(w util.BufWriter, source []byte, node ast
 		bl := r.c.Block()
 		block, ok := bl.(*notionapi.TableRowBlock)
 		if !ok {
-			fmt.Printf("%T", bl)
-			panic("foo")
+			return ast.WalkStop, fmt.Errorf("expected parent block to be a notionapi.TableRowBlock but got %T", bl)
 		}
 		block.TableRow.Cells = append(block.TableRow.Cells, []notionapi.RichText{})
 	}

--- a/repository.go
+++ b/repository.go
@@ -53,6 +53,12 @@ func NewRepo(path string, ref string) (*Repo, error) {
 		},
 	}
 
+	// We check the existence of the path before anything else, because otherwise
+	// filepath.Walk will fail with a cryptic error message (nil pointer).
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+
 	err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
 		if filepath.Base(p) == ".git" {
 			return filepath.SkipDir

--- a/repository_test.go
+++ b/repository_test.go
@@ -15,7 +15,7 @@ func TestNewRepo(t *testing.T) {
 			"foo/index.md",
 		}
 
-		repo, err := NewRepo("../testdata/", "testref")
+		repo, err := NewRepo("testdata/", "testref")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -30,7 +30,7 @@ func TestNewRepo(t *testing.T) {
 }
 
 func TestFindDocument(t *testing.T) {
-	repo, err := NewRepo("../testdata/", "testref")
+	repo, err := NewRepo("testdata/", "testref")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testdata/ref/table.md
+++ b/testdata/ref/table.md
@@ -7,3 +7,8 @@ Glorious days ahead!
 | 1 | 1 | 1 | 
 | *foo* is a common _term_ | _bar_ | **baz** |
 | [link](https://github.com) | `code` | |
+
+
+| A | B | C |
+|:---|:---:|---:| 
+| 1 | 1 | 1 | 

--- a/testdata/ref/table.md
+++ b/testdata/ref/table.md
@@ -1,0 +1,9 @@
+# We can use tables too
+
+Glorious days ahead! 
+
+| A | B | C |
+|---|---|---| 
+| 1 | 1 | 1 | 
+| *foo* is a common _term_ | _bar_ | **baz** |
+| [link](https://github.com) | `code` | |


### PR DESCRIPTION
As I was going through what's left to import the dev docs, noticed we had a few tables over there, which this PR provides support for. 

I also fixed a nasty bug when inserting top level elements, which was due to incorrectly handling the cursor when inserting headings. 

Finally, there's a curious hardcoded `200` value (with a comment of course), which caused me to pull my hairs for a while: when you pass the `extensions.GFM` for table support, the underlying code is also attaching rendering functions for HTML rendering them, with a priority of `500`. 

While this is quite suprising, it's in the `goldmark` code and the rationale for it is I suppose that it's just more convenient. I think we could untangle that by using the lower level API for the configuring options, but it's not very much worth the effort at this stage. 